### PR TITLE
Fix InheritdocInliner task execution

### DIFF
--- a/src/NatsnudaLibrary/NatsnudaLibrary.csproj
+++ b/src/NatsnudaLibrary/NatsnudaLibrary.csproj
@@ -58,6 +58,9 @@
     </PackageReference>
   </ItemGroup>
   <Target Name="ReplaceInheritdoc" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
-    <Exec Command='"$(PkgInheritdocInliner)\tools\InheritdocInliner.exe" "$(OutputPath)Natsnudasoft.NatsnudaLibrary.xml"' />
+    <Exec
+      Command='"$(PkgInheritdocInliner)\tools\InheritdocInliner.exe" "$(OutputPath)Natsnudasoft.NatsnudaLibrary.xml"'
+      IgnoreStandardErrorWarningFormat="true"
+      StandardOutputImportance="low" />
   </Target>
 </Project>

--- a/src/TestExtensions/TestExtensions.csproj
+++ b/src/TestExtensions/TestExtensions.csproj
@@ -69,6 +69,9 @@
     <ProjectReference Include="..\NatsnudaLibrary\NatsnudaLibrary.csproj" />
   </ItemGroup>
   <Target Name="ReplaceInheritdoc" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
-    <Exec Command='"$(PkgInheritdocInliner)\tools\InheritdocInliner.exe" "$(OutputPath)Natsnudasoft.NatsnudaLibrary.xml"' />
+    <Exec
+      Command='"$(PkgInheritdocInliner)\tools\InheritdocInliner.exe" "$(OutputPath)Natsnudasoft.NatsnudaLibrary.TestExtensions.xml"'
+      IgnoreStandardErrorWarningFormat="true"
+      StandardOutputImportance="low" />
   </Target>
 </Project>


### PR DESCRIPTION
Stop InheritdocInliner reporting warnings and outputting to default build output.
Fix incorrect TestExtensions InheritdocInliner path.